### PR TITLE
add bot toggle ability

### DIFF
--- a/src/bot.js
+++ b/src/bot.js
@@ -7,11 +7,15 @@ let conversationToken;
 let expiration;
 const azureBotToken = process.env.AzureBotToken;
 
-module.exports = {
-  createNewBotConversation,
-  triggerEffect,
-  sendCommand
+const noop = () => {};
+const botEnabled = process.env.BOT_ENABLED.toLocaleLowerCase() === 'true';
+const bot = {
+  createNewBotConversation: botEnabled ? createNewBotConversation : noop,
+  triggerEffect: botEnabled ? triggerEffect : noop,
+  sendCommand: botEnabled ? sendCommand : noop
 };
+
+module.exports = bot;
 
 function createNewBotConversation() {
   captains.log(`Starting a new bot conversation at: ${new Date()}`);

--- a/src/chat.js
+++ b/src/chat.js
@@ -48,6 +48,7 @@ function pingTtv() {
 }
 
 ttvChatClient.on('join', (channel, username, self) => {
+  // TODO: refactor this to be it's own function since it's not relative to this function
   const date = new Date();
   const rawMinutes = date.getMinutes();
   const rawHours = date.getHours();


### PR DESCRIPTION
## Purpose

<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->

- This abstracts out the bot functionality so that if someone wants to use this project without the bot/bulb they can do so through the environment variable configuration.

## Does this introduce a breaking change?

<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

## Pull Request Type

What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

## How to Test

<!-- please provide details how to manually test the changes being implemented when applicable -->

- Get the code

```
git clone git@github.com:clarkio/ttv-chat-light.git
cd ttv-chat-light
git checkout config-drive-bot-toggle
npm install
```

1. Update `.env` file to include a `BOT_ENABLED` variable with a value of either `true` or `false`.
2. Run npm start

### What to Check

Verify that the following are valid

- You can enable or disable the bot component by using an environment variable `BOT_ENABLED`
- Verify there are no errors when the bot is disabled (aka `BOT_ENABLED` environment variable is set to `false`)

## Other Information

<!-- Add any other helpful information that may be needed here. -->
