### PR TITLE
Add Custom Overlay Color Editor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@
 /src/**/*.js.map
 /dist/*
 
+# custom css files
+src/assets/custom-styles.css
+
 # Logs
 logs
 *.log
@@ -61,4 +64,3 @@ typings/
 
 # dotenv environment variables file
 .env
-

--- a/package-lock.json
+++ b/package-lock.json
@@ -644,20 +644,46 @@
       "integrity": "sha1-vPEwUspURj8w+fx+lbmkdjCpSSE="
     },
     "body-parser": {
-      "version": "1.18.2",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.18.2.tgz",
-      "integrity": "sha1-h2eKGdhLR9hZuDGZvVm84iKxBFQ=",
+      "version": "1.18.3",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.18.3.tgz",
+      "integrity": "sha1-WykhmP/dVTs6DyDe0FkrlWlVyLQ=",
       "requires": {
         "bytes": "3.0.0",
         "content-type": "~1.0.4",
         "debug": "2.6.9",
-        "depd": "~1.1.1",
-        "http-errors": "~1.6.2",
-        "iconv-lite": "0.4.19",
+        "depd": "~1.1.2",
+        "http-errors": "~1.6.3",
+        "iconv-lite": "0.4.23",
         "on-finished": "~2.3.0",
-        "qs": "6.5.1",
-        "raw-body": "2.3.2",
-        "type-is": "~1.6.15"
+        "qs": "6.5.2",
+        "raw-body": "2.3.3",
+        "type-is": "~1.6.16"
+      },
+      "dependencies": {
+        "iconv-lite": {
+          "version": "0.4.23",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
+          "integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
+          "requires": {
+            "safer-buffer": ">= 2.1.2 < 3"
+          }
+        },
+        "qs": {
+          "version": "6.5.2",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+          "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
+        },
+        "raw-body": {
+          "version": "2.3.3",
+          "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.3.3.tgz",
+          "integrity": "sha512-9esiElv1BrZoI3rCDuOuKCBRbuApGGaDPQfjSflGxdy4oyzqghxu6klEkkVIvBje+FF0BX9coEv8KqW6X/7njw==",
+          "requires": {
+            "bytes": "3.0.0",
+            "http-errors": "1.6.3",
+            "iconv-lite": "0.4.23",
+            "unpipe": "1.0.0"
+          }
+        }
       }
     },
     "bops": {
@@ -1951,6 +1977,23 @@
         "vary": "~1.1.2"
       },
       "dependencies": {
+        "body-parser": {
+          "version": "1.18.2",
+          "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.18.2.tgz",
+          "integrity": "sha1-h2eKGdhLR9hZuDGZvVm84iKxBFQ=",
+          "requires": {
+            "bytes": "3.0.0",
+            "content-type": "~1.0.4",
+            "debug": "2.6.9",
+            "depd": "~1.1.1",
+            "http-errors": "~1.6.2",
+            "iconv-lite": "0.4.19",
+            "on-finished": "~2.3.0",
+            "qs": "6.5.1",
+            "raw-body": "2.3.2",
+            "type-is": "~1.6.15"
+          }
+        },
         "safe-buffer": {
           "version": "5.1.1",
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "author": "Brian Clark",
   "license": "MIT",
   "dependencies": {
+    "body-parser": "^1.18.3",
     "discord.js": "^11.3.2",
     "dotenv": "^5.0.1",
     "es6-promise": "^4.2.5",

--- a/src/files.ts
+++ b/src/files.ts
@@ -1,0 +1,21 @@
+import { appendFile, existsSync, writeFile } from 'fs';
+import { resolve as resolvePath } from 'path';
+
+const FILE_NAME = resolvePath(__dirname, '../src/assets/custom-styles.css');
+
+export function write(data: any) {
+  if (existsSync(FILE_NAME)) {
+    return new Promise((resolve, reject) => {
+      appendFile(FILE_NAME, data, (err: any) => {
+        if (err) reject(err);
+        resolve(data);
+      });
+    });
+  }
+  return new Promise((resolve, reject) => {
+    writeFile(FILE_NAME, data, (err: any) => {
+      if (err) reject(err);
+      resolve(data);
+    });
+  });
+}

--- a/src/routes/save-css.ts
+++ b/src/routes/save-css.ts
@@ -1,0 +1,21 @@
+import express from 'express';
+import * as files from '../files';
+
+export const saveCssRoute = (req: express.Request, res: express.Response) => {
+  const captains = console;
+  captains.log(req.body);
+  const { colorName, hueRotateDeg } = req.body;
+  const data = formatForCSS(colorName, hueRotateDeg);
+  files
+    .write(data)
+    .then((result: any) => {
+      res.send({ message: 'Saved' });
+    })
+    .catch((error: any) => {
+      res.status(500).send(error);
+    });
+};
+
+function formatForCSS(colorName: string, hueRotateDeg: string) {
+  return `.${colorName} {\n  filter: hue-rotate(${hueRotateDeg}deg);\n}\n`;
+}

--- a/src/scripts/overlay-colors.js
+++ b/src/scripts/overlay-colors.js
@@ -1,17 +1,50 @@
 $(document).ready(() => {
-  let hueValue = 0;
+  const captains = console;
   $('#get-overlay').click(() => {
     const url = $('#overlay-url').val();
     $('#overlay-frame').attr('src', url);
   });
 
   $('#increase-hue').click(() => {
-    hueValue = hueValue < 361 ? (hueValue += 1) : 360;
-    $('#container').css('filter', `hue-rotate(${hueValue}deg)`);
+    let currentHueValue = $('#rotation').val();
+    const hueValue = currentHueValue < 361 ? (currentHueValue += 1) : 360;
+    applyHue(hueValue);
   });
 
   $('#decrease-hue').click(() => {
-    hueValue = hueValue > 0 ? (hueValue -= 1) : 0;
-    $('#container').css('filter', `hue-rotate(${hueValue}deg)`);
+    let currentHueValue = $('#rotation').val();
+    const hueValue = currentHueValue > 0 ? (currentHueValue -= 1) : 0;
+    applyHue(hueValue);
   });
+
+  $('#save-color').click(() => {
+    const hueRotateDeg = $('#rotation').val();
+    const colorName = $('#color-name').val();
+    const data = JSON.stringify({ colorName, hueRotateDeg });
+    const requestOptions = {
+      url: '/save',
+      method: 'POST',
+      data,
+      contentType: 'application/json'
+    };
+    request(requestOptions).done(result => captains.log(result));
+  });
+
+  $('#update-hue').click(() => {
+    const hueRotateDeg = $('#rotation').val();
+    applyHue(hueRotateDeg);
+  });
+
+  function applyHue(hueRotateDeg) {
+    $('#container').css('filter', `hue-rotate(${hueRotateDeg}deg)`);
+  }
+
+  function request(requestOptions) {
+    return $.ajax(requestOptions)
+      .done(result => result)
+      .fail(error => {
+        captains.error(error);
+        return error;
+      });
+  }
 });

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,3 +1,4 @@
+import bodyParser from 'body-parser';
 import { WebhookClient } from 'discord.js';
 import express = require('express');
 import { Server } from 'http';
@@ -9,6 +10,7 @@ import { DiscordBot } from './discord-bot';
 import { log } from './log';
 import { Overlay } from './overlay';
 import { changeLightColor, sendLightEffect } from './routes/lights';
+import { saveCssRoute } from './routes/save-css';
 import { scenesRoute } from './routes/scenes';
 
 /**
@@ -70,6 +72,7 @@ export class AppServer {
    * Config Express
    */
   private configApp(): void {
+    this.app.use(bodyParser.json());
     this.app.set('view engine', 'pug');
     this.app.set('views', `${__dirname}/views`);
     this.app.use(express.static(__dirname));
@@ -81,6 +84,8 @@ export class AppServer {
   private defineRoutes(): void {
     const router: express.Router = express.Router();
     router.get('/scenes', scenesRoute);
+
+    router.post('/save', saveCssRoute);
 
     router.get('/overlay-colors', (req, res) => {
       res.render('overlay-colors');

--- a/src/server.ts
+++ b/src/server.ts
@@ -27,10 +27,10 @@ export class AppServer {
 
   constructor() {
     this.app = express();
+    this.configApp();
     this.startDiscordHook();
     this.startOverlay();
     this.defineRoutes();
-    this.configApp();
     this.startAzureBot();
     this.listen();
   }

--- a/src/views/index.pug
+++ b/src/views/index.pug
@@ -2,6 +2,7 @@ doctype html
 html(lang='en')
     head
         link(rel='stylesheet', href='../assets/styles.css', type='text/css')
+        link(rel='stylesheet', href='../assets/custom-styles.css', type='text/css')
         script(src='https://code.jquery.com/jquery-3.3.1.min.js', integrity='sha256-FgpCb/KJQlLNfOu91ta32o/NMZxltwRo8QtmkMRdAu8=', crossorigin='anonymous')
         script(src='/socket.io/socket.io.js')
         script(src='../scripts/stream.js')

--- a/src/views/overlay-colors.pug
+++ b/src/views/overlay-colors.pug
@@ -11,6 +11,10 @@ html(lang='en')
         br
         button#increase-hue(style={height:'40px;', width:'70px;'}) Up ⬆
         button#decrease-hue(style={height:'40px;', width:'70px;'}) Down ⬇
+        input#rotation(style={height:'40px;', width:'100px;'})
+        button#update-hue(style={height:'40px;', width:'70px;'}) Update Hue
+        input#color-name(style={height:'40px;', width:'100px;'})
+        button#save-color(style={height:'40px;', width:'70px;'}) Save Color
         br        
         div#container
             iframe#overlay-frame(style={height:'720px;', width:'1280px;'})


### PR DESCRIPTION
## Purpose

<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->

- This adds a new view/endpoint that allows users to load up overlay URLs, adjust the hue of the overlay and save the color in a custom css file to be used later.

## Does this introduce a breaking change?

<!-- Mark one with an "x". -->

- [ ] Yes
- [ ] No

## Pull Request Type

What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

## How to Test

<!-- please provide details how to manually test the changes being implemented when applicable -->

- Get the code

```
git clone git@github.com:clarkio/ttv-chat-light.git
cd ttv-chat-client
git checkout [branch-name]
npm install
```

### What to Check

Verify that the following are valid

- ...

## Other Information

<!-- Add any other helpful information that may be needed here. -->
