### PR TITLE
Serial parsing of audio tracks using music-metadata

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1039,16 +1039,6 @@
       "resolved": "https://registry.npmjs.org/blob/-/blob-0.0.4.tgz",
       "integrity": "sha1-vPEwUspURj8w+fx+lbmkdjCpSSE="
     },
-    "bluebird": {
-      "version": "3.5.3",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.3.tgz",
-      "integrity": "sha512-/qKPUQlaW1OyR51WeCPBvRnAlnZFUJkCSG5HzGnuIqhgyJtF+T94lFnn33eiazjRm2LAHVy2guNnaq48X9SJuw=="
-    },
-    "bluebird-co": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/bluebird-co/-/bluebird-co-2.2.0.tgz",
-      "integrity": "sha1-4KSeY7axfjTJH0izk0t2mjd/vtc="
-    },
     "body-parser": {
       "version": "1.18.3",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.18.3.tgz",
@@ -2665,6 +2655,11 @@
       "requires": {
         "flat-cache": "^2.0.1"
       }
+    },
+    "file-type": {
+      "version": "12.3.0",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-12.3.0.tgz",
+      "integrity": "sha512-4E4Esq9KLwjYCY32E7qSmd0h7LefcniZHX+XcdJ4Wfx1uGJX7QCigiqw/U0yT7WOslm28yhxl87DJ0wHYv0RAA=="
     },
     "file-uri-to-path": {
       "version": "1.0.0",
@@ -4664,19 +4659,43 @@
       "resolved": "https://registry.npmjs.org/mp3/-/mp3-0.1.0.tgz",
       "integrity": "sha1-5T5HI+NGmO4//dzbYL+INWpJEME="
     },
-    "mp3-duration": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/mp3-duration/-/mp3-duration-1.1.0.tgz",
-      "integrity": "sha1-wALk5FREgGCHNmCrtNp9EBGNDpw=",
-      "requires": {
-        "bluebird": "^3.5.1",
-        "bluebird-co": "^2.2.0"
-      }
-    },
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+    },
+    "music-metadata": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/music-metadata/-/music-metadata-4.5.0.tgz",
+      "integrity": "sha512-/Zl6PkgQ4A6CDhDrY9wi5A/VDAAl7rNYCqZegBoOk8+QxQOpS1ebuKZYpJA7L2dJD8L7wgPIlltsCsdu7izKEQ==",
+      "requires": {
+        "content-type": "^1.0.4",
+        "debug": "^4.1.0",
+        "file-type": "^12.1.0",
+        "media-typer": "^1.1.0",
+        "strtok3": "^3.0.0",
+        "token-types": "^1.0.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "media-typer": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+          "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw=="
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        }
+      }
     },
     "mute-stream": {
       "version": "0.0.7",
@@ -7200,6 +7219,31 @@
       "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
       "dev": true
     },
+    "strtok3": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-3.0.0.tgz",
+      "integrity": "sha512-Sm17gVuapi4jR5cE6UnYhstZ7jGeH9a/eM7Sbg5IDk6bw3Z7FF0UTA1tnZo2Gt7OmY+/O9kVAnAGJ9mglvf36w==",
+      "requires": {
+        "debug": "^4.1.1",
+        "then-read-stream": "^2.0.0",
+        "token-types": "^1.0.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        }
+      }
+    },
     "supports-color": {
       "version": "5.4.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
@@ -7313,6 +7357,11 @@
         "promise": ">=3.2 <8"
       }
     },
+    "then-read-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/then-read-stream/-/then-read-stream-2.0.0.tgz",
+      "integrity": "sha512-mdQRdZ+71UVL9H6y2bRt/SlpIgzi223LEx8gxbRCfVURnXrokMYo1w+jNcATTZLR25kVUb+h8X6BlmoW4173fQ=="
+    },
     "through": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
@@ -7423,6 +7472,11 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/token-stream/-/token-stream-0.0.1.tgz",
       "integrity": "sha1-zu78cXp2xDFvEm0LnbqlXX598Bo="
+    },
+    "token-types": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/token-types/-/token-types-1.0.2.tgz",
+      "integrity": "sha512-LIPDJaj2AfarYhA08cUguadmGDo3DGeDQmg4w12H76yDntpjJudX4RqTpxRjLhvYCUrzHTcXk1k2/AZqSV8HcA=="
     },
     "toml": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "express": "^4.16.3",
     "hoek": "^5.0.3",
     "isomorphic-fetch": "^2.2.1",
-    "mp3-duration": "^1.1.0",
+    "music-metadata": "^4.5.0",
     "obs-websocket-js": "^2.0.1",
     "play-sound": "^1.1.3",
     "pug": "^2.0.3",


### PR DESCRIPTION
## Purpose

* Prevent parallel parsing of audio tracks (MP3's), fixes #97
* Use [music-metadata](https://github.com/borewit/music-metadata) instead of mp3-duration

Why music-metadata? TypeScript build in, promise based, well maintained and supported. 

## Does this introduce a breaking change?

**I have not tested it.**

## Pull Request Type

What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->

- Bugfix
- Refactoring (no functional changes, no api changes)

## How to Test

<!-- please provide details how to manually test the changes being implemented when applicable -->

- Get the code

```
git clone git@github.com:clarkio/ttv-chat-light.git
cd ttv-chat-client
git checkout [branch-name]
npm install
```

### What to Check

Is the duration of audio files done correctly?
Should be faster if a bunch of audio tracks are requested to be processed. 
## Other Information

If you need any help, let me know
